### PR TITLE
Resolve issue, 'make' does not install pkgs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='studi',
-    version='1.0.1',
+    version='1.0.2',
     long_description=__doc__,
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'flask',
-        'flask-restful'
+        'flask>=0.12.0',
+        'flask-restful>=0.3.0'
     ],
 )


### PR DESCRIPTION
When we didn't specify the version info of each packages in setup.py,
there was a bug that setuptools does not install required packages.

By specifying the packages version in setup.py, the bug was solved.