### PR TITLE
Handling log and exception

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ venv:
 	virtualenv --python=python3 venv && venv/bin/python setup.py develop
 
 run: venv
-	FLASK_APP=studi STUDI_SETTINGS=../settings.cfg venv/bin/flask run --host=0.0.0.0 --port=5000
+	export FLASK_ENV=production && FLASK_APP=studi STUDI_SETTINGS=../settings.cfg venv/bin/flask run --host=0.0.0.0 --port=5000
 
 test: venv
 	STUDI_SETTINGS=../settings.cfg venv/bin/python -m unittest discover -s tests

--- a/settings.cfg
+++ b/settings.cfg
@@ -1,1 +1,0 @@
-DEBUG = True

--- a/studi/__init__.py
+++ b/studi/__init__.py
@@ -4,34 +4,14 @@ from flask import Flask
 module_path = os.path.dirname(os.path.abspath(__file__))
 
 app = Flask(__name__)
-app.config.from_object('studi.default_settings')
-try:
-    app.config.from_envvar('STUDI_SETTINGS')
-except RuntimeError:
-    pass
-if not app.debug:
-    import logging
-    from logging.handlers import TimedRotatingFileHandler
-    # https://docs.python.org/3.6/library/logging.handlers.html#timedrotatingfilehandler
-    file_handler = TimedRotatingFileHandler(os.path.join(app.config['LOG_DIR'], 'studi.log'), 'midnight')
-    file_handler.setLevel(logging.WARNING)
-    file_handler.setFormatter(logging.Formatter('<%(asctime)s> <%(levelname)s> %(message)s'))
-    app.logger.addHandler(file_handler)
-else:
-   import logging
-   from logging.handlers import TimedRotatingFileHandler
-   # https://docs.python.org/3.6/library/logging.handlers.html#timedrotatingfilehandler
-   file_handler = TimedRotatingFileHandler(os.path.join(app.config['TEST_LOG_DIR'], 'studi_debug.log'), 'midnight')
-   file_handler.setLevel(logging.DEBUG)
-   file_handler.setFormatter(logging.Formatter('<%(asctime)s> <%(levelname)s> %(message)s'))
-   app.logger.addHandler(file_handler)
+app.config.from_object('studi.config')
 
 
-import studi.rest_apis
 import studi.upload
 import studi.views
 import studi.sqlalchemy_orm
 import studi.log
+import studi.rest_apis
 import studi.custom_error
 
 if not os.path.exists('studi/db/studi.db'):

--- a/studi/__init__.py
+++ b/studi/__init__.py
@@ -9,7 +9,6 @@ try:
     app.config.from_envvar('STUDI_SETTINGS')
 except RuntimeError:
     pass
-
 if not app.debug:
     import logging
     from logging.handlers import TimedRotatingFileHandler
@@ -20,9 +19,9 @@ if not app.debug:
     app.logger.addHandler(file_handler)
 else:
    import logging
-   from logging import FileHandler
+   from logging.handlers import TimedRotatingFileHandler
    # https://docs.python.org/3.6/library/logging.handlers.html#timedrotatingfilehandler
-   file_handler = FileHandler(os.path.join(app.config['LOG_DIR'], 'studi_debug.log'))
+   file_handler = TimedRotatingFileHandler(os.path.join(app.config['TEST_LOG_DIR'], 'studi_debug.log'), 'midnight')
    file_handler.setLevel(logging.DEBUG)
    file_handler.setFormatter(logging.Formatter('<%(asctime)s> <%(levelname)s> %(message)s'))
    app.logger.addHandler(file_handler)
@@ -31,7 +30,7 @@ else:
 import studi.rest_apis
 import studi.upload
 import studi.views
-import studi.sqlalchemy
+import studi.sqlalchemy_orm
 
 if not os.path.exists('studi/db/studi.db'):
-    studi.sqlalchemy.create_db(True)
+    studi.sqlalchemy_orm.create_db(True)

--- a/studi/__init__.py
+++ b/studi/__init__.py
@@ -31,6 +31,8 @@ import studi.rest_apis
 import studi.upload
 import studi.views
 import studi.sqlalchemy_orm
+import studi.log
+import studi.custom_error
 
 if not os.path.exists('studi/db/studi.db'):
     studi.sqlalchemy_orm.create_db(True)

--- a/studi/config.py
+++ b/studi/config.py
@@ -1,0 +1,5 @@
+ENV = 'production' # make sure ENV is always production
+DEBUG = False  # make sure DEBUG is off unless enabled explicitly otherwise
+TESTING = False # make sure TESTING is off
+LOG_DIR = './studi/logs/'  # create log files in current working directory
+TEST_LOG_DIR = '.'

--- a/studi/custom_error.py
+++ b/studi/custom_error.py
@@ -1,3 +1,4 @@
+from studi import app
 from studi import log
 
 class BaseError(Exception):
@@ -8,6 +9,7 @@ class BaseError(Exception):
         self.message = message
         self.params = params
         self.error_message = error_message
+        self.logger = log.logger
 
     def __str__(self):
         return self.message
@@ -16,11 +18,21 @@ class BaseError(Exception):
         params = ''
         if self.params:
             params = ''.join(f'{key}: {value}' for key, value in self.params.items())
-
-        log.logger.error('Exception, code : {0}, status : {1}, message : {2}, parms : {3}, error_message : {4}'.format(self.code, self.status, self.message, params, self.error_message))
+        self.logger.error('Exception, code : {0}, status : {1}, message : {2}, parms : {3}, error_message : {4}'.format(self.code, self.status, self.message, params, self.error_message))
 
         response = {'code' : self.code, 'status' : self.status, 'message' : self.message}
         return response
+
+    def set_logger(self, logger):
+        self.logger = logger
+
+class AssertionError(BaseError):
+    def __init__(self, error_message):
+        BaseError.__init__(self)
+        self.code = 500
+        self.status = 'AssertionError'
+        self.message = '검증에 실패했습니다.'
+        self.error_message = error_message
 
 
 class AttributeError(BaseError):
@@ -33,11 +45,12 @@ class AttributeError(BaseError):
 
 
 class UnExpectedError(BaseError):
-    def __init__(self):
+    def __init__(self, error_message=''):
         BaseError.__init__(self)
         self.code = 500
         self.status = "UnExpectedError"
         self.message = '예기치 못한 서버 오류가 발생했습니다. 관리자에게 문의해주세요'
+        self.error_message = error_message
 
 
 class BadRequestError(BaseError):

--- a/studi/custom_error.py
+++ b/studi/custom_error.py
@@ -1,0 +1,93 @@
+from studi import log
+
+class BaseError(Exception):
+    def __init__(self, code=400, status='', message='', params=[], error_message=''):
+        Exception.__init__(self)
+        self.code = code
+        self.status = status
+        self.message = message
+        self.params = params
+        self.error_message = error_message
+
+    def __str__(self):
+        return self.message
+
+    def to_dict(self):
+        params = ''
+        if self.params:
+            params = ''.join(f'{key}: {value}' for key, value in self.params.items())
+
+        log.logger.error('Exception, code : {0}, status : {1}, message : {2}, parms : {3}, error_message : {4}'.format(self.code, self.status, self.message, params, self.error_message))
+
+        response = {'code' : self.code, 'status' : self.status, 'message' : self.message}
+        return response
+
+
+class AttributeError(BaseError):
+    def __init__(self, error_message):
+        BaseError.__init__(self)
+        self.code = 500
+        self.status = 'AttributeError'
+        self.message = '인스턴스의 속성 이름이나 모듈의 이름이 잘못되었습니다. 해당 인스턴스에 속성이 있는지 확인해주세요'
+        self.error_message = error_message
+
+
+class UnExpectedError(BaseError):
+    def __init__(self):
+        BaseError.__init__(self)
+        self.code = 500
+        self.status = "UnExpectedError"
+        self.message = '예기치 못한 서버 오류가 발생했습니다. 관리자에게 문의해주세요'
+
+
+class BadRequestError(BaseError):
+    def __init__(self):
+        BaseError.__init__(self)
+        self.code = 400
+        self.status = 'Bad Request'
+        self.message = '요청에 필요한 파라미터 값이 존재하지 않거나 올바르지 않은 파라미터 값이 포함되었습니다'
+        # self.params = params
+        # self.error_message = error_message
+
+
+class HTTPRequestError(BaseError):
+    def __init__(self, error_message):
+        BaseError.__init__(self)
+        self.code = 400
+        self.status = "HTTPException"
+        self.message = '잘못된 요청이 들어와 요청을 처리하지 못하였습니다.'
+        self.error_message = error_message
+
+
+class SQLAlchemyNotInsertError(BaseError):
+    def __init__(self, error_message):
+        BaseError.__init__(self)
+        self.code = 500
+        self.status = 'NotInserted'
+        self.message = 'SQLAlchemy에서 원인을 알 수 없는 이유로 DB에 데이터가 저장되지 않았습니다.'
+
+
+class SQLAlchemyError(BaseError):
+    def __init__(self, error_message):
+        BaseError.__init__(self)
+        self.code = 500
+        self.status = 'SQLALchemyError'
+        self.message = 'DB 요청을 처리하는데 문제가 발생하였습니다.'
+        self.error_message = error_message
+
+
+class CSVError(BaseError):
+    def __init__(self, error_message):
+        BaseError.__init__(self)
+        self.code = 400
+        self.status = 'CSVError'
+        self.message = 'csv 파일을 처리하는데 문제가 발생하였습니다. csv 파일이 비어있거나 파일 내부 형식이 잘못되었습니다.'
+        self.error_message = error_message
+
+
+class NotCSVFileError(BaseError):
+    def __init__(self, filename):
+        BaseError.__init__(self)
+        self.code = 400
+        self.status = 'NotCSVFileError'
+        self.message = '요청하신 {0} 파일은 csv 형태가 아닙니다. 파일 형식을 다시 확인하여 주세요'.format(filename)

--- a/studi/default_settings.py
+++ b/studi/default_settings.py
@@ -1,2 +1,3 @@
-DEBUG = False  # make sure DEBUG is off unless enabled explicitly otherwise
-LOG_DIR = '.'  # create log files in current working directory
+DEBUG = True  # make sure DEBUG is off unless enabled explicitly otherwise
+LOG_DIR = './studi/logs/'  # create log files in current working directory
+TEST_LOG_DIR = '.'

--- a/studi/default_settings.py
+++ b/studi/default_settings.py
@@ -1,3 +1,0 @@
-DEBUG = True  # make sure DEBUG is off unless enabled explicitly otherwise
-LOG_DIR = './studi/logs/'  # create log files in current working directory
-TEST_LOG_DIR = '.'

--- a/studi/log.py
+++ b/studi/log.py
@@ -23,3 +23,5 @@ def logger_decorator_with_params(logger):
             return result
         return decorator
     return wrapper
+
+logger = gen_logger('studi')

--- a/studi/log.py
+++ b/studi/log.py
@@ -1,16 +1,32 @@
 import os
-import studi
+from studi import app
 import logging
+from logging.handlers import TimedRotatingFileHandler
 from flask import request
 
 def gen_logger(module_name):
     logger = logging.getLogger(module_name)
     logger.setLevel(logging.DEBUG)
-    logger_handler = logging.FileHandler(os.path.join(studi.app.config['LOG_DIR'], module_name + '.log'))
-    logger_handler.setLevel(logging.DEBUG)
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    logger_handler.setFormatter(formatter)
-    logger.addHandler(logger_handler)
+    if app.config['TESTING']:
+        # https://docs.python.org/3.6/library/logging.handlers.html#timedrotatingfilehandler
+        file_handler = TimedRotatingFileHandler(os.path.join(app.config['TEST_LOG_DIR'], 'studi_debug.log'),
+                                                'midnight')
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(logging.Formatter('<%(asctime)s> <%(levelname)s> %(message)s'))
+        logger.addHandler(file_handler)
+        return logger
+
+    if app.config['ENV'] == 'production':
+        file_handler = TimedRotatingFileHandler(os.path.join(app.config['LOG_DIR'], 'studi.log'), 'midnight')
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(logging.Formatter('<%(asctime)s> <%(levelname)s> %(message)s'))
+        logger.addHandler(file_handler)
+    else:
+        file_handler = TimedRotatingFileHandler(os.path.join(app.config['LOG_DIR'], 'studi_debug.log'), 'midnight')
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(logging.Formatter('<%(asctime)s> <%(levelname)s> %(message)s'))
+        logger.addHandler(file_handler)
+
     return logger
 
 

--- a/studi/log.py
+++ b/studi/log.py
@@ -1,0 +1,25 @@
+import os
+import studi
+import logging
+from flask import request
+
+def gen_logger(module_name):
+    logger = logging.getLogger(module_name)
+    logger.setLevel(logging.DEBUG)
+    logger_handler = logging.FileHandler(os.path.join(studi.app.config['LOG_DIR'], module_name + '.log'))
+    logger_handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logger_handler.setFormatter(formatter)
+    logger.addHandler(logger_handler)
+    return logger
+
+
+def logger_decorator_with_params(logger):
+    def wrapper(func):
+        def decorator(*args, **kwargs):
+            logger.info('REQUEST, {0}, params : {1}'.format(request.environ['werkzeug.request'], kwargs))
+            result = func(*args, **kwargs)
+            logger.info("RESPONSE, {0}".format(result))
+            return result
+        return decorator
+    return wrapper

--- a/studi/models/__init__.py
+++ b/studi/models/__init__.py
@@ -1,9 +1,0 @@
-from .notes import Notes
-from .clauses import Clauses
-from .clausePoints import ClausePoints
-
-__all__ = [
-    'Notes',
-    'Clauses',
-    'ClausePoints'
-]

--- a/studi/rest_apis.py
+++ b/studi/rest_apis.py
@@ -1,81 +1,151 @@
 
 from flask_restful import Api, Resource
+from werkzeug.exceptions import HTTPException
 from studi import sqlalchemy_orm
 from studi import app
 from flask import request, Response
 from studi import upload
 from studi import log
+from studi import custom_error
+import sqlalchemy
+from studi import util
+
+
 import csv
 
 api = Api(app)
 
-logger = log.gen_logger('studi')
+
 
 class Note(Resource):
 
     def __init__(self):
         pass
 
-    @log.logger_decorator_with_params(logger)
-    def get(self, note_id=None):
+    @log.logger_decorator_with_params(log.logger)
+    def get(self):
         try:
-            if note_id:
-                result = sqlalchemy_orm.get_item_from_db(sqlalchemy_orm.Notes, {'note_id': note_id})
-            else:
-                result = sqlalchemy_orm.get_all_data_from_db(sqlalchemy_orm.Notes)
-        except Exception as exc:
-            app.logger.debug("Exception raised during 'GET date from Notes; {0}".format(str(exc)))
-            return {'notes' : None}, 500
+            result = sqlalchemy_orm.get_all_data_from_db(sqlalchemy_orm.Notes)
+        except sqlalchemy.exc.SQLAlchemyError:
+            error_message = util.traceback_custom_error()
+            response = custom_error.SQLAlchemyError(error_message).to_dict()
+            return response, 500
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
         else:
             if result:
                 return {'notes' : result}, 200
-            else:
-                return {'notes' : result}, 201
+            return {'notes': []}, 201
 
-    @log.logger_decorator_with_params(logger)
+
+    @log.logger_decorator_with_params(log.logger)
     def post(self):
         try:
-            file = request.files['studi_material']
-            file_name = file.filename.split('/').pop()
-
-            # Cross-site scripting (XSS)
-            if file_name[-3:] != "csv":
-                app.logger.debug(
-                    "Exception raised during upload new file file name is : {0}".format(file_name))
-                return {'result' : False, \
-                        'description' : "file's extenstion is not .csv. You should upload csv file. \
-                        Uploaded file name is : {0}".format(file_name)}, 400
-
             request_file = request.files['studi_material']
-            csvfile = request_file.read().decode("utf-8").splitlines()
-            note = csv.DictReader(csvfile)
-            if upload.save_csv_contents_to_db(file_name[:-4], note, True):
-                return {'result': True}, 200
-            else:
-                return {'result': False}, 400
-        except Exception as exc:
-            app.logger.debug("Exception raised during POST note to Notes; {0}".format(str(exc)))
-            return {'result' : False}, 500
+            file_name = request_file.filename.split('/').pop()
+        except HTTPException:
+            error_message = util.traceback_custom_error()
+            response = custom_error.HTTPRequestError(error_message).to_dict()
+            return response, 400
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 400
 
-    @log.logger_decorator_with_params(logger)
-    def delete(self, note_id):
+
+        # Cross-site scripting (XSS)
+        if file_name[-3:] != "csv":
+            return custom_error.NotCSVFileError(file_name).to_dict(), 400
+
         try:
-            sqlalchemy_orm.delete_note_and_related_data_from_db(int(note_id))
-        except Exception as exc:
-            app.logger.debug("Exception raised during Delete note from Notes; {0}".format(str(exc)))
-            return {'result' : False}, 500
+            csvfile = request_file.read().decode("utf-8").splitlines()
+            # empty csv file
+            if not csvfile:
+                return custom_error.CSVError('csv file is empty'.format(csvfile)).to_dict(), 400
+            note = csv.DictReader(csvfile)
+        except csv.Error:
+            error_message = util.traceback_custom_error()
+            return custom_error.CSVError(error_message).to_dict(), 400
+
+        try:
+            new_note_id = upload.save_csv_contents_to_db(file_name[:-4], note, True)
+        except sqlalchemy.exc.SQLAlchemyError:
+            error_message = util.traceback_custom_error()
+            response = custom_error.SQLAlchemyError(error_message).to_dict()
+            return response, 500
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
         else:
-            # Todo ADD Verification Code
             return {'result': True}, 200
 
-    @log.logger_decorator_with_params(logger)
+
+
+    @log.logger_decorator_with_params(log.logger)
+    def delete(self, note_id):
+        if isinstance(note_id, str):
+            if not note_id.isdigit():
+                return custom_error.BadRequestError().to_dict(), 400
+            note_id = int(note_id)
+
+        if note_id < 1:
+            return custom_error.BadRequestError().to_dict(), 400
+
+        try:
+            deleted_note = sqlalchemy_orm.delete_note_and_related_data_from_db(note_id)
+        except sqlalchemy.exc.SQLAlchemyError:
+            error_message = util.traceback_custom_error()
+            response = custom_error.SQLAlchemyError(error_message).to_dict()
+            return response, 500
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
+        else:
+            # 존재하지 않은 노트에 대한 처리
+            if not deleted_note:
+                return custom_error.BadRequestError().to_dict(), 400
+            return {'result': True}, 200
+
+
+    @log.logger_decorator_with_params(log.logger)
     def put(self, note_id):
-        new_note_name = request.form['new_note_name']
+        if isinstance(note_id, str):
+            if not note_id.isdigit():
+                return custom_error.BadRequestError().to_dict(), 400
+            note_id = int(note_id)
+
+        if note_id < 1:
+            return custom_error.BadRequestError().to_dict(), 400
+
+        try:
+            new_note_name = request.form['new_note_name']
+        except HTTPException:
+            error_message = util.traceback_custom_error()
+            response = custom_error.HTTPRequestError(error_message).to_dict()
+            return response, 400
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 400
+
+        # note_name is not empty
+        if not new_note_name:
+            return custom_error.BadRequestError().to_dict(), 400
+
         try:
             sqlalchemy_orm.update_data_to_db(sqlalchemy_orm.Notes, {'note_id' : note_id}, {'note_name' : new_note_name})
-        except Exception as exc:
-            app.logger.debug("Exception raised during Delete note from Notes; {0}".format(str(exc)))
-            return {'result' : False}, 500
+        except sqlalchemy.exc.SQLAlchemyError:
+            error_message = util.traceback_custom_error()
+            response = custom_error.SQLAlchemyError(error_message).to_dict()
+            return response, 500
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
         else:
             return {'result' : True}, 200
 
@@ -86,65 +156,149 @@ class Clause(Resource):
     def __init__(self):
         pass
 
-    @log.logger_decorator_with_params(logger)
+    @log.logger_decorator_with_params(log.logger)
     def get(self, clause_id):
+        if isinstance(clause_id, str):
+            if not clause_id.isdigit():
+                return custom_error.BadRequestError().to_dict(), 400
+            clause_id = int(clause_id)
+
+        if clause_id < 1:
+            return custom_error.BadRequestError().to_dict(), 400
+
         try:
             result = sqlalchemy_orm.get_item_from_db(sqlalchemy_orm.Clauses, {'clause_id' : clause_id})
-        except Exception as exc:
-            app.logger.debug(
-                "Exception raised during get data from clause ".format( clause_id, str(exc))
-            )
-            return { 'clause' }, 500
+        except sqlalchemy.exc.SQLAlchemyError:
+            error_message = util.traceback_custom_error()
+            response = custom_error.SQLAlchemyError(error_message).to_dict()
+            return response, 500
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
         if result:
                 return {'clause' : result}, 200
-        else:
-            return {'clause' : result}, 201
+        return {'clause' : []}, 201
 
-    @log.logger_decorator_with_params(logger)
+
+    @log.logger_decorator_with_params(log.logger)
     def post(self):
         try:
+            note_id = request.form['note_id']
+            title = request.form['title']
+            contents = request.form['contents']
+
+            if not note_id or not title or not contents:
+                return custom_error.BadRequestError().to_dict(), 400
+
+            if isinstance(note_id, str):
+                if not note_id.isdigit():
+                    return custom_error.BadRequestError().to_dict(), 400
+                note_id = int(note_id)
+
+            if note_id < 1:
+                return custom_error.BadRequestError().to_dict(), 400
+
             new_clause_id = sqlalchemy_orm.insert_data_to_db('Clauses', \
-                                                             sqlalchemy_orm.Clauses(request.form['note_id'], \
-                                                                                    request.form['title'], \
-                                                                                    request.form['contents']))
-        except Exception as exc:
-            return {'clause_id' : None, 'title': None, 'contents' : None}, 500
-        else:
-            if new_clause_id:
-                return {'clause_id' : new_clause_id, 'title' : request.form['title'], 'contents' : request.form['contents']}, 200
-            else:
-                return {'clause_id': None, 'title': None, 'contents': None}, 500
+                                                             sqlalchemy_orm.Clauses(note_id, \
+                                                                                    title, \
+                                                                                  contents))
+            if not new_clause_id:
+                raise custom_error.SQLAlchemyNotInsertError
 
-    @log.logger_decorator_with_params(logger)
+        except HTTPException:
+            error_message = util.traceback_custom_error()
+            response = custom_error.HTTPRequestError(error_message).to_dict()
+            return response, 400
+        except sqlalchemy.exc.SQLAlchemyError:
+            error_message = util.traceback_custom_error()
+            response = custom_error.SQLAlchemyError(error_message).to_dict()
+            return response, 500
+        except custom_error.SQLAlchemyNotInsertError:
+            return custom_error.SQLAlchemyNotInsertError().to_dict(), 500
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
+        else:
+            return {'clause_id' : new_clause_id, 'title' : title, 'contents' : contents}, 200
+
+
+    @log.logger_decorator_with_params(log.logger)
     def delete(self, clause_id):
+        if isinstance(clause_id, str):
+            if not clause_id.isdigit():
+                return custom_error.BadRequestError().to_dict(), 400
+            clause_id = int(clause_id)
+
         try:
-
             result = sqlalchemy_orm.delete_data_from_db(sqlalchemy_orm.Clauses, {'clause_id' : clause_id})
-        except Exception as exc:
-            return {'clause_id': None}, 500
-        else:
-            if result:
-                result = result[0]
-                clause_id = getattr(result, 'clause_id')
-                return {'clause_id': clause_id}, 200
-            else:
-                return {'clause_id': None}, 500
+            if not result:
+                raise custom_error.BadRequestError
 
-    @log.logger_decorator_with_params(logger)
+        except sqlalchemy.exc.SQLAlchemyError:
+            error_message = util.traceback_custom_error()
+            response = custom_error.SQLAlchemyError(error_message).to_dict()
+            return response, 500
+        except custom_error.SQLAlchemyNotInsertError:
+            return custom_error.SQLAlchemyNotInsertError().to_dict(), 500
+        except custom_error.BadRequestError:
+            return custom_error.BadRequestError().to_dict(), 500
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
+
+        try:
+            result = result[0]
+            clause_id = getattr(result, 'clause_id')
+            return {'clause_id': clause_id}, 200
+
+        except AttributeError:
+            error_message = util.traceback_custom_error()
+            custom_error.AttributeError(error_message).to_dict()
+            return {'clause_id' : None}, 201
+
+
+    @log.logger_decorator_with_params(log.logger)
     def put(self, clause_id):
-        update_data = {}
-        for key, value in request.form.items():
-            update_data[key] = value
+
+        if isinstance(clause_id, str):
+            if not clause_id.isdigit():
+                return custom_error.BadRequestError().to_dict(), 400
+            clause_id = int(clause_id)
+
+        try:
+            update_data = {}
+            for key, value in request.form.items():
+                update_data[key] = value
+        except HTTPException:
+            error_message = util.traceback_custom_error()
+            response = custom_error.HTTPRequestError(error_message).to_dict()
+            return response, 400
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
 
         try:
             clause = sqlalchemy_orm.update_data_to_db(sqlalchemy_orm.Clauses, {'clause_id' : clause_id}, update_data)
-        except Exception as exc:
-            return {'clause_id':clause_id, 'clause' : None}, 500
+            if not clause:
+                raise custom_error.BadRequestError
+
+        except sqlalchemy.exc.SQLAlchemyError:
+            error_message = util.traceback_custom_error()
+            response = custom_error.SQLAlchemyError(error_message).to_dict()
+            return response, 500
+        except custom_error.BadRequestError:
+            response = custom_error.BadRequestError().to_dict(), 400
+            return response, 400
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
         else:
-            if clause:
-                return {'clause_id':clause_id, 'clause' : clause}, 200
-            else:
-                return {'clause_id':clause_id, 'clause' : clause}, 201
+            return {'clause_id':clause_id, 'clause' : clause}, 200
 
 
 
@@ -153,46 +307,76 @@ class ClausePoint(Resource):
     def __init__(self):
         pass
 
-    @log.logger_decorator_with_params(logger)
+    @log.logger_decorator_with_params(log.logger)
     def get(self, **args):
-
-        for key, value in request.args.items():
-            args[key] = value
+        try:
+            for key, value in request.args.items():
+                args[key] = value
+        except HTTPException:
+            error_message = util.traceback_custom_error()
+            response = custom_error.HTTPRequestError(error_message).to_dict()
+            return response, 400
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
 
         try:
             result = sqlalchemy_orm.get_item_from_db(sqlalchemy_orm.ClausePoints, args)
-        except Exception as exc:
-            app.logger.debug(
-                "Exception raised during 'SELECT * FROM ClausePoints WHERE args={0}' query: {1}".format(
-                    args, str(exc)
-                )
-            )
-            return {'note_id': args['note_id'], 'clause_points' : None}, 500
+            if not result:
+                raise custom_error.BadRequestError
+
+        except sqlalchemy.exc.SQLAlchemyError:
+            error_message = util.traceback_custom_error()
+            response = custom_error.SQLAlchemyError(error_message).to_dict()
+            return response, 500
+        except custom_error.BadRequestError:
+            response = custom_error.BadRequestError().to_dict()
+            return response, 400
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
         else:
-            if result:
-                    return {'note_id': args['note_id'], 'clause_points': result}, 200
-            else:
-                return {'note_id': args['note_id'], 'clause_points' : result}, 201
+            return {'note_id': args['note_id'], 'clause_points': result}, 200
+
 
 
     # 포인트 정보 업데이트
-    @log.logger_decorator_with_params(logger)
+    @log.logger_decorator_with_params(log.logger)
     def put(self, clause_id):
-        update_data = {}
-        for key, value in request.form.items():
-            update_data[key] = value
+        try:
+            update_data = {}
+            for key, value in request.form.items():
+                update_data[key] = value
+        except HTTPException:
+            error_message = util.traceback_custom_error()
+            response = custom_error.HTTPRequestError(error_message).to_dict()
+            return response, 400
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
+
         try:
             clause_point = sqlalchemy_orm.update_data_to_db(sqlalchemy_orm.ClausePoints, {'clause_id' : clause_id}, update_data)
-        except Exception as exc:
+            if not clause_point:
+                raise custom_error.BadRequestError
 
-            app.logger.debug("Exception raised during 'Update point data to ClausePoints.\
-            clause_id : {0}, update_data :{1}, error: {2}".format(clause_id, update_data, str(exc)))
-            return {'clause_id' : clause_id, 'clause_point' : None}, 500
+        except sqlalchemy.exc.SQLAlchemyError:
+            error_message = util.traceback_custom_error()
+            response = custom_error.SQLAlchemyError(error_message).to_dict()
+            return response, 500
+        except custom_error.BadRequestError:
+            response = custom_error.BadRequestError().to_dict()
+            return response, 400
+        except:
+            error_message = util.traceback_custom_error()
+            response = custom_error.UnExpectedError(error_message).to_dict()
+            return response, 500
         else:
-            if clause_point:
-                return {'clause_id': clause_id, 'clause_point' : clause_point}, 200
-            else:
-                return {'clause_id': clause_id, 'clause_point': clause_point}, 201
+            return {'clause_id': clause_id, 'clause_point' : clause_point}, 200
+
 
 
 

--- a/studi/rest_apis.py
+++ b/studi/rest_apis.py
@@ -1,26 +1,28 @@
 
 from flask_restful import Api, Resource
-from studi import sqlalchemy
+from studi import sqlalchemy_orm
 from studi import app
 from flask import request, Response
 from studi import upload
+from studi import log
 import csv
 
 api = Api(app)
 
+logger = log.gen_logger('studi')
 
 class Note(Resource):
-
 
     def __init__(self):
         pass
 
+    @log.logger_decorator_with_params(logger)
     def get(self, note_id=None):
         try:
             if note_id:
-                result = sqlalchemy.get_item_from_db(sqlalchemy.Notes, {'note_id': note_id})
+                result = sqlalchemy_orm.get_item_from_db(sqlalchemy_orm.Notes, {'note_id': note_id})
             else:
-                result = sqlalchemy.get_all_data_from_db(sqlalchemy.Notes)
+                result = sqlalchemy_orm.get_all_data_from_db(sqlalchemy_orm.Notes)
         except Exception as exc:
             app.logger.debug("Exception raised during 'GET date from Notes; {0}".format(str(exc)))
             return {'notes' : None}, 500
@@ -30,7 +32,7 @@ class Note(Resource):
             else:
                 return {'notes' : result}, 201
 
-
+    @log.logger_decorator_with_params(logger)
     def post(self):
         try:
             file = request.files['studi_material']
@@ -55,10 +57,10 @@ class Note(Resource):
             app.logger.debug("Exception raised during POST note to Notes; {0}".format(str(exc)))
             return {'result' : False}, 500
 
-
+    @log.logger_decorator_with_params(logger)
     def delete(self, note_id):
         try:
-            sqlalchemy.delete_note_and_related_data_from_db(int(note_id))
+            sqlalchemy_orm.delete_note_and_related_data_from_db(int(note_id))
         except Exception as exc:
             app.logger.debug("Exception raised during Delete note from Notes; {0}".format(str(exc)))
             return {'result' : False}, 500
@@ -66,11 +68,11 @@ class Note(Resource):
             # Todo ADD Verification Code
             return {'result': True}, 200
 
-
+    @log.logger_decorator_with_params(logger)
     def put(self, note_id):
         new_note_name = request.form['new_note_name']
         try:
-            sqlalchemy.update_data_to_db(sqlalchemy.Notes, {'note_id' : note_id}, {'note_name' : new_note_name})
+            sqlalchemy_orm.update_data_to_db(sqlalchemy_orm.Notes, {'note_id' : note_id}, {'note_name' : new_note_name})
         except Exception as exc:
             app.logger.debug("Exception raised during Delete note from Notes; {0}".format(str(exc)))
             return {'result' : False}, 500
@@ -84,9 +86,10 @@ class Clause(Resource):
     def __init__(self):
         pass
 
+    @log.logger_decorator_with_params(logger)
     def get(self, clause_id):
         try:
-            result = sqlalchemy.get_item_from_db(sqlalchemy.Clauses, {'clause_id' : clause_id})
+            result = sqlalchemy_orm.get_item_from_db(sqlalchemy_orm.Clauses, {'clause_id' : clause_id})
         except Exception as exc:
             app.logger.debug(
                 "Exception raised during get data from clause ".format( clause_id, str(exc))
@@ -97,12 +100,13 @@ class Clause(Resource):
         else:
             return {'clause' : result}, 201
 
+    @log.logger_decorator_with_params(logger)
     def post(self):
         try:
-            new_clause_id = sqlalchemy.insert_data_to_db('Clauses', \
-                                                         sqlalchemy.Clauses(request.form['note_id'], \
-                                                                            request.form['title'], \
-                                                                            request.form['contents']))
+            new_clause_id = sqlalchemy_orm.insert_data_to_db('Clauses', \
+                                                             sqlalchemy_orm.Clauses(request.form['note_id'], \
+                                                                                    request.form['title'], \
+                                                                                    request.form['contents']))
         except Exception as exc:
             return {'clause_id' : None, 'title': None, 'contents' : None}, 500
         else:
@@ -111,11 +115,11 @@ class Clause(Resource):
             else:
                 return {'clause_id': None, 'title': None, 'contents': None}, 500
 
-
+    @log.logger_decorator_with_params(logger)
     def delete(self, clause_id):
         try:
 
-            result = sqlalchemy.delete_data_from_db(sqlalchemy.Clauses, {'clause_id' : clause_id})
+            result = sqlalchemy_orm.delete_data_from_db(sqlalchemy_orm.Clauses, {'clause_id' : clause_id})
         except Exception as exc:
             return {'clause_id': None}, 500
         else:
@@ -126,13 +130,14 @@ class Clause(Resource):
             else:
                 return {'clause_id': None}, 500
 
+    @log.logger_decorator_with_params(logger)
     def put(self, clause_id):
         update_data = {}
         for key, value in request.form.items():
             update_data[key] = value
 
         try:
-            clause = sqlalchemy.update_data_to_db(sqlalchemy.Clauses, {'clause_id' : clause_id}, update_data)
+            clause = sqlalchemy_orm.update_data_to_db(sqlalchemy_orm.Clauses, {'clause_id' : clause_id}, update_data)
         except Exception as exc:
             return {'clause_id':clause_id, 'clause' : None}, 500
         else:
@@ -148,14 +153,14 @@ class ClausePoint(Resource):
     def __init__(self):
         pass
 
-
+    @log.logger_decorator_with_params(logger)
     def get(self, **args):
 
         for key, value in request.args.items():
             args[key] = value
 
         try:
-            result = sqlalchemy.get_item_from_db(sqlalchemy.ClausePoints, args)
+            result = sqlalchemy_orm.get_item_from_db(sqlalchemy_orm.ClausePoints, args)
         except Exception as exc:
             app.logger.debug(
                 "Exception raised during 'SELECT * FROM ClausePoints WHERE args={0}' query: {1}".format(
@@ -171,12 +176,13 @@ class ClausePoint(Resource):
 
 
     # 포인트 정보 업데이트
+    @log.logger_decorator_with_params(logger)
     def put(self, clause_id):
         update_data = {}
         for key, value in request.form.items():
             update_data[key] = value
         try:
-            clause_point = sqlalchemy.update_data_to_db(sqlalchemy.ClausePoints, {'clause_id' : clause_id}, update_data)
+            clause_point = sqlalchemy_orm.update_data_to_db(sqlalchemy_orm.ClausePoints, {'clause_id' : clause_id}, update_data)
         except Exception as exc:
 
             app.logger.debug("Exception raised during 'Update point data to ClausePoints.\

--- a/studi/sqlalchemy_orm.py
+++ b/studi/sqlalchemy_orm.py
@@ -71,6 +71,9 @@ def get_item_from_db(table, *args):
         query = query.filter(or_(*or_query))
     items = query.all()
 
+    if not items:
+        return []
+
     results = []
     if items:
         for item in items:
@@ -107,6 +110,9 @@ def delete_data_from_db(table, *args):
         query = query.filter(or_(*or_query))
     items = query.all()
 
+    if not items:
+        return []
+
     for item in items:
         db.session.delete(item)
         db.session.commit()
@@ -118,6 +124,10 @@ def delete_data_from_db(table, *args):
 def delete_note_and_related_data_from_db(note_id):
     query = db.session.query(Notes)
     note = query.filter(getattr(Notes, 'note_id') == note_id).one()
+
+    if not note:
+        return None
+
     # all() return list []
     db.session.delete(note)
     db.session.commit()
@@ -138,6 +148,9 @@ def update_data_to_db(table, condition, update_data):
         query = query.filter(getattr(table, attr) == value)
 
     models = query.all()
+
+    if not models:
+        return []
 
     for model in models:
         for key, value in update_data.items():

--- a/studi/sqlalchemy_orm.py
+++ b/studi/sqlalchemy_orm.py
@@ -1,7 +1,10 @@
-from .models.extentions import db
-from .models import Notes, Clauses, ClausePoints
 from sqlalchemy import or_
 from studi import app
+from .models.extentions import db
+from .models.notes import Notes
+from .models.clauses import Clauses
+from .models.clausePoints import ClausePoints
+
 
 # Create table (defalut, production = False)
 def create_db(Production=False):
@@ -35,7 +38,7 @@ def get_all_data_from_db(table):
     :param table: data model object
     :return: (dict) result
     """
-    items = table.query.all()
+    items = db.session.query(table)
     results = []
     if items:
         for item in items:

--- a/studi/upload.py
+++ b/studi/upload.py
@@ -2,7 +2,7 @@
 from flask_restful import Api
 
 from studi import app
-from studi import sqlalchemy
+from studi import sqlalchemy_orm
 
 import csv
 
@@ -13,19 +13,19 @@ def save_csv_contents_to_db(file_name, note, Production=False):
         app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db/test_studi.db'
 
     # Data model object
-    Notes = sqlalchemy.Notes
-    Clauses = sqlalchemy.Clauses
-    ClausePoints = sqlalchemy.ClausePoints
+    Notes = sqlalchemy_orm.Notes
+    Clauses = sqlalchemy_orm.Clauses
+    ClausePoints = sqlalchemy_orm.ClausePoints
     try:
-        note_id = sqlalchemy.insert_data_to_db("Notes", Notes(file_name))
+        note_id = sqlalchemy_orm.insert_data_to_db("Notes", Notes(file_name))
         for clauses_dict in note:
             title = None
             content = None
             for key, value in clauses_dict.items():
                 if key == 'title': title = value
                 if key == 'content': content = value
-            clauses_id = sqlalchemy.insert_data_to_db("Clauses", Clauses(note_id, title, content))
-            sqlalchemy.insert_data_to_db("ClausePoints", ClausePoints(clauses_id, note_id, 0, 0))
+            clauses_id = sqlalchemy_orm.insert_data_to_db("Clauses", Clauses(note_id, title, content))
+            sqlalchemy_orm.insert_data_to_db("ClausePoints", ClausePoints(clauses_id, note_id, 0, 0))
     except Exception as exc:
         # TODO: more elegant exception handling..
         app.logger.warn(

--- a/studi/upload.py
+++ b/studi/upload.py
@@ -16,22 +16,17 @@ def save_csv_contents_to_db(file_name, note, Production=False):
     Notes = sqlalchemy_orm.Notes
     Clauses = sqlalchemy_orm.Clauses
     ClausePoints = sqlalchemy_orm.ClausePoints
-    try:
-        note_id = sqlalchemy_orm.insert_data_to_db("Notes", Notes(file_name))
-        for clauses_dict in note:
-            title = None
-            content = None
-            for key, value in clauses_dict.items():
-                if key == 'title': title = value
-                if key == 'content': content = value
-            clauses_id = sqlalchemy_orm.insert_data_to_db("Clauses", Clauses(note_id, title, content))
-            sqlalchemy_orm.insert_data_to_db("ClausePoints", ClausePoints(clauses_id, note_id, 0, 0))
-    except Exception as exc:
-        # TODO: more elegant exception handling..
-        app.logger.warn(
-            "Exception raised during DB insertions: {0}".format(exc))
-    else:
-        return note_id
+
+    note_id = sqlalchemy_orm.insert_data_to_db("Notes", Notes(file_name))
+    for clauses_dict in note:
+        title = None
+        content = None
+        for key, value in clauses_dict.items():
+            if key == 'title': title = value
+            if key == 'content': content = value
+        clauses_id = sqlalchemy_orm.insert_data_to_db("Clauses", Clauses(note_id, title, content))
+        sqlalchemy_orm.insert_data_to_db("ClausePoints", ClausePoints(clauses_id, note_id, 0, 0))
+    return note_id
 
 
 def insert_csv_to_db(Production=False):

--- a/studi/util.py
+++ b/studi/util.py
@@ -1,0 +1,10 @@
+import traceback
+
+def traceback_custom_error():
+    lines = traceback.format_exc().split('\n')
+    error = [lines[-1]]
+    lines = lines[1:-1]
+    lines.reverse()
+    for i in range(0, len(lines) - 1, 2):
+        error.append('\t{0} at {1}'.format(lines[i].strip(), lines[i + 1].strip()))
+    return '\n'.join(error)

--- a/tests/test_create_db.py
+++ b/tests/test_create_db.py
@@ -1,14 +1,15 @@
 import logging
 import os
+import sqlalchemy
 import unittest
 
-import studi
-from studi import sqlalchemy
+from studi import app
+from studi import sqlalchemy_orm, util, custom_error
 
 def gen_logger(test_name):
     logger = logging.getLogger(test_name)
     logger.setLevel(logging.DEBUG)
-    logger_handler = logging.FileHandler(os.path.join(studi.app.config['LOG_DIR'], test_name + '.log'))
+    logger_handler = logging.FileHandler(os.path.join(app.config['TEST_LOG_DIR'], test_name + '.log'))
     logger_handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     logger_handler.setFormatter(formatter)
@@ -18,46 +19,75 @@ def gen_logger(test_name):
 test_name = "test_create_db"
 logger = gen_logger(test_name)
 
-
 # Testing that create DB by using flask_sqlalchemy(ORM)
 class TestCreateDB(unittest.TestCase):
 
     def setUp(self):
-        studi.app.testing = True
-        studi.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db/test_studi.db'
+        app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db/test_studi.db'
+
 
         # delete db
         if os.path.exists("../studi/db/test_studi.db"):
-            sqlalchemy.drop_db(False)
-            self.app = studi.app.test_client()
+            sqlalchemy_orm.drop_db(False)
+            self.app = app.test_client()
 
 
     def test_create_db(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
-                db = sqlalchemy.create_db(False)
-            except Exception as exc:
-                logger.debug("Cannot create db, Error : {0}".format(exc))
-            finally:
+                db = sqlalchemy_orm.create_db(False)
                 table_names = db.engine.table_names()
                 self.assertIn('notes', table_names)
                 self.assertIn('clauses', table_names)
                 self.assertIn('clause_points', table_names)
 
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+
+
     def test_delete_db(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
-                db = sqlalchemy.drop_db(False)
-            except Exception as exc:
-                logger.debug('Cannot delete db, Error : {1}'.format(exc))
-            finally:
+                db = sqlalchemy_orm.drop_db(False)
                 table_names = db.engine.table_names()
                 self.assertEqual(table_names, [])
                 self.assertEqual(len(table_names), 0)
 
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
-    def tearDown(self):
-        studi.app.testing = False
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_delete.py
+++ b/tests/test_delete.py
@@ -1,16 +1,17 @@
 import logging
 import os
+import sqlalchemy
 import unittest
 
 from studi import app
-from studi import sqlalchemy
-from studi import upload
-from studi.sqlalchemy import Notes, Clauses, ClausePoints
+from studi import sqlalchemy_orm, upload, util, custom_error
+from studi.sqlalchemy_orm import Notes, Clauses, ClausePoints
+
 
 def gen_logger(test_name):
     logger = logging.getLogger(test_name)
     logger.setLevel(logging.DEBUG)
-    logger_handler = logging.FileHandler(os.path.join(app.config['LOG_DIR'], test_name + '.log'))
+    logger_handler = logging.FileHandler(os.path.join(app.config['TEST_LOG_DIR'], test_name + '.log'))
     logger_handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     logger_handler.setFormatter(formatter)
@@ -27,13 +28,12 @@ class TestDeleteDB(unittest.TestCase):
     """
     def setUp(self):
         self.app = app.test_client()
-        app.testing = True
         app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db/test_studi.db'
 
         #create new tesint DB & insert dummy data
         if os.path.exists("../studi/db/test_studi.db"):
-            sqlalchemy.drop_db(False)
-        sqlalchemy.create_db(False)
+            sqlalchemy_orm.drop_db(False)
+        sqlalchemy_orm.create_db(False)
         upload.insert_csv_to_db(False)  # note_id : 1
         upload.insert_csv_to_db(False)  # note_id : 2
         upload.insert_csv_to_db(False)  # note_id : 3
@@ -44,18 +44,33 @@ class TestDeleteDB(unittest.TestCase):
     def test_delete_one_note(self):
         with app.app_context():
             try:
-                sqlalchemy.delete_note_and_related_data_from_db(3)
-            except Exception as exc:
-                logger.debug('Cannot delete note and related data from other tables, because {0}'.format(exc))
-            finally:
+                sqlalchemy_orm.delete_note_and_related_data_from_db(3)
                 # Check if result is empty
-                note_result = sqlalchemy.get_item_from_db(Notes, {'note_id' : 3})
-                clauses_result = sqlalchemy.get_item_from_db(Clauses, {'note_id' : 3})
-                clausePoints_result = sqlalchemy.get_item_from_db(ClausePoints, {'note_id' : 3})
+                note_result = sqlalchemy_orm.get_item_from_db(Notes, {'note_id' : 3})
+                clauses_result = sqlalchemy_orm.get_item_from_db(Clauses, {'note_id' : 3})
+                clausePoints_result = sqlalchemy_orm.get_item_from_db(ClausePoints, {'note_id' : 3})
                 self.assertEqual(note_result, [])
                 self.assertEqual(clauses_result, [])
                 self.assertEqual(clausePoints_result, [])
 
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
     # Delete multiple Note (with related clause, clausePoints Data)
@@ -63,13 +78,29 @@ class TestDeleteDB(unittest.TestCase):
     def test_delete_multiple_note(self):
         with app.app_context():
             try:
-                sqlalchemy.delete_data_from_db(Notes, {'note_id' : [1, 2]})
-            except Exception as exc:
-                logger.debug("Cannot delete multiple notes data, because : {0}".format(exc))
-            finally:
+                sqlalchemy_orm.delete_data_from_db(Notes, {'note_id' : [1, 2]})
                 # Check if result is empty
-                note_result = sqlalchemy.get_item_from_db(Notes, {'note_id' : [1, 2]})
+                note_result = sqlalchemy_orm.get_item_from_db(Notes, {'note_id' : [1, 2]})
                 self.assertEqual(note_result, [])
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
     # Delete Clause (with related clausePoints)
@@ -77,20 +108,33 @@ class TestDeleteDB(unittest.TestCase):
     def test_delete_clause(self):
         with app.app_context():
             try:
-                sqlalchemy.delete_data_from_db(Clauses, {'clause_id' : 11})
-            except Exception as exc:
-                logger.debug("Cannot delete clause and related points data, baluse : {0}".format(exc))
-            finally:
-                clause_result = sqlalchemy.get_item_from_db(Clauses, {'clause_id' : 11})
-                clause_point_result = sqlalchemy.get_item_from_db(ClausePoints, {'clause_id' : 11})
+                sqlalchemy_orm.delete_data_from_db(Clauses, {'clause_id' : 11})
+                clause_result = sqlalchemy_orm.get_item_from_db(Clauses, {'clause_id' : 11})
+                clause_point_result = sqlalchemy_orm.get_item_from_db(ClausePoints, {'clause_id' : 11})
 
                 # Check if result is empty
                 self.assertEqual(clause_result,[])
                 self.assertEqual(clause_point_result, [])
 
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
-    def tearDown(self):
-        app.testing = False
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -1,16 +1,16 @@
 import logging
 import os
+import sqlalchemy
 import unittest
 
-import studi
-from studi import sqlalchemy
-from studi import upload
+from studi import app
+from studi import sqlalchemy_orm, upload, util, custom_error
 
 
 def gen_logger(test_name):
     logger = logging.getLogger(test_name)
     logger.setLevel(logging.DEBUG)
-    logger_handler = logging.FileHandler(os.path.join(studi.app.config['LOG_DIR'], test_name + '.log'))
+    logger_handler = logging.FileHandler(os.path.join(app.config['TEST_LOG_DIR'], test_name + '.log'))
     logger_handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     logger_handler.setFormatter(formatter)
@@ -27,63 +27,116 @@ class TestInsertDB(unittest.TestCase):
     """
 
     def setUp(self):
-        studi.app.testing = True
-        self.app = studi.app.test_client()
+        self.app = app.test_client()
         # create new testing db
         if os.path.exists("../studi/db/test_studi.db"):
-            sqlalchemy.drop_db(False)
-        self.db = sqlalchemy.create_db(False)
+            sqlalchemy_orm.drop_db(False)
+        self.db = sqlalchemy_orm.create_db(False)
 
 
     def test_insert_note_db(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
-                Notes = sqlalchemy.Notes
-                note_id  = sqlalchemy.insert_data_to_db('Notes', Notes('test_title_1'))
-            except Exception as exc:
-                logger.debug('Cannot insert data to db(Notes), Error : {0}'.format(exc))
-            finally:
+                Notes = sqlalchemy_orm.Notes
+                note_id  = sqlalchemy_orm.insert_data_to_db('Notes', Notes('test_title_1'))
                 self.assertIsNotNone(note_id)
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
     def test_insert_clause_db(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
-                Clauses = sqlalchemy.Clauses
-                clauses_id = sqlalchemy.insert_data_to_db('Clauses', Clauses(1, "test_clause_1", "test_content_1"))
-            except Exception as exc:
-                logger.debug("Cannot insert to db(Clauses), Error : {0}".format(exc))
-            finally:
+                Clauses = sqlalchemy_orm.Clauses
+                clauses_id = sqlalchemy_orm.insert_data_to_db('Clauses', Clauses(1, "test_clause_1", "test_content_1"))
                 self.assertIsNotNone(clauses_id)
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
     def test_insert_clausePoints_db(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
-                clausePoints = sqlalchemy.ClausePoints
+                clausePoints = sqlalchemy_orm.ClausePoints
                 # column = ['clause_id', 'note_id', 'imp', 'und']
-                clausepoints_id = sqlalchemy.insert_data_to_db("ClausePoints", clausePoints(1, 1))
-            except Exception as exc:
-                logger.debug("Cannot insert to db(CluasePoints), Error: {0}".format(exc))
-            finally:
+                clausepoints_id = sqlalchemy_orm.insert_data_to_db("ClausePoints", clausePoints(1, 1))
                 self.assertIsNotNone(clausepoints_id)
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
     def test_insert_csv_to_db(self):
-        with studi.app.app_context():
-            if os.path.exists('../studi/uploads/studi_test_file.csv'):
+        with app.app_context():
+            if os.path.exists('../studi/uploads/studi_test_files.csv'):
                 try:
                     note_id = upload.insert_csv_to_db()
-                except Exception as exc:
-                    logger.debug("Cannot read csv file Even though csv file exists, Error : {0}".format(exc))
-                finally:
                     self.assertIsNotNone(note_id)
-            else:
-                logger.debug("There is not csv file")
-
-
-    def tearDown(self):
-        studi.app.testing = False
+                except sqlalchemy.exc.SQLAlchemyError:
+                    error_message = util.traceback_custom_error()
+                    error = custom_error.SQLAlchemyError(error_message)
+                    error.set_logger(logger)
+                    error.to_dict()
+                    raise
+                except AssertionError:
+                    error_message = util.traceback_custom_error()
+                    error = custom_error.AssertionError(error_message)
+                    error.set_logger(logger)
+                    error.to_dict()
+                    raise
+                except:
+                    error_message = util.traceback_custom_error()
+                    error = custom_error.UnExpectedError(error_message)
+                    error.set_logger(logger)
+                    error.to_dict()
+                    raise
 
 
 if __name__ == "__main__":

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -3,18 +3,20 @@
 import logging
 import os
 import unittest
-from studi import app
-from studi import upload
 import json
+import sqlalchemy
 
-import studi
-from studi import sqlalchemy
+
+from studi import app
+from studi import upload, util, custom_error
+
+from studi import sqlalchemy_orm
 
 
 def gen_logger(test_name):
     logger = logging.getLogger(test_name)
     logger.setLevel(logging.DEBUG)
-    logger_handler = logging.FileHandler(os.path.join(studi.app.config['LOG_DIR'], test_name + '.log'))
+    logger_handler = logging.FileHandler(os.path.join(app.config['TEST_LOG_DIR'], test_name + '.log'))
     logger_handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     logger_handler.setFormatter(formatter)
@@ -27,108 +29,168 @@ logger = gen_logger(test_name)
 class TestRestAPI(unittest.TestCase):
 
     def setUp(self):
-        studi.app.testing = True
-        self.app = studi.app.test_client()
+        self.app = app.test_client()
         app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db/test_studi.db'
-
 
         # create new testing db & insert dummy data
         if os.path.exists("../studi/db/test_studi.db"):
-            sqlalchemy.drop_db(False)
-        self.db = sqlalchemy.create_db(False)
+            sqlalchemy_orm.drop_db(False)
+        self.db = sqlalchemy_orm.create_db(False)
         upload.insert_csv_to_db(False) # note_id : 1
         upload.insert_csv_to_db(False) # note_id : 2
         upload.insert_csv_to_db(False) # note_id : 3
 
     # @unittest.skip("skipping")
     def test_get_notes(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
                 resp = self.app.get('/api/notes')
                 data = json.loads(resp.data)
-            except Exception as exc:
-                logger.debug("Cannot GET notes from db(Notes), Error : {0}".format(exc))
-                print('GET Notes, Error : {0}'.format(exc))
-            finally:
                 self.assertIsInstance(data['notes'], list)
                 self.assertNotEqual(len(data['notes']), 0)
                 self.assertEqual(resp.status_code, 200)
 
-    # @unittest.skip("skipping")
-    def test_get_note(self):
-        with studi.app.app_context():
-            try:
-                resp = self.app.get('/api/notes/2')
-                data = json.loads(resp.data)
-            except Exception as exc:
-                logger.debug("Cannot GET note from db(Notes), Error : {0}".format(exc))
-                print('GET note, Error : {0}'.format(exc))
-            finally:
-                self.assertIsInstance(data['notes'], list)
-                self.assertEqual(resp.status_code, 200)
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+
 
     # @unittest.skip("skipping")
     def test_post_note(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
                 data = {
                     'studi_material': open('../studi/uploads/studi_test_file.csv', 'rb')
                 }
                 resp = self.app.post('/api/notes', data=data, content_type='multipart/form-data')
                 data = json.loads(resp.data)
-            except Exception as exc:
-                logger.debug("Cannot POST note to db(Notes), Error : {0}".format(exc))
-                print('POST Note, Error : {0}'.format(exc))
-            finally:
                 self.assertEqual(data['result'], True)
                 self.assertEqual(resp.status_code, 200)
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
     # @unittest.skip("skipping")
     def test_delete_note(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
                 resp = self.app.delete('/api/notes/1')
                 data = json.loads(resp.data)
-            except Exception as exc:
-                logger.debug("Cannot DELETE note in db(Notes), Error : {0}".format(exc))
-                print('DELETE Note, Error : {0}'.format(exc))
-            finally:
                 self.assertEqual(data['result'], True)
                 self.assertEqual(resp.status_code, 200)
 
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+
     # @unittest.skip("skipping")
     def test_put_note(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
                 data = {
                     'new_note_name' : 'new_note_name'
                 }
                 resp = self.app.put('/api/notes/1', data=data, content_type='multipart/form-data')
                 data = json.loads(resp.data)
-            except Exception as exc:
-                logger.debug("Cannot PUT note to db(Notes), Error : {0}".format(exc))
-                print('PUT note name, Error : {0}'.format(exc))
-            finally:
                 self.assertEqual(data['result'], True)
                 self.assertEqual(resp.status_code, 200)
 
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+
     # @unittest.skip("skipping")
     def test_get_clause(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
                 resp = self.app.get('/api/clauses/1')
                 data = json.loads(resp.data)
-
-            except Exception as exc:
-                logger.debug("Cannot GET clause to db(Clauses), Error : {0}".format(exc))
-                print('GET clause, Error : {0}'.format(exc))
-            finally:
                 self.assertIsNotNone(data['clause'])
                 self.assertEqual(resp.status_code, 200)
 
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+
     # @unittest.skip("skipping")
     def test_post_clause(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
                 data = {
                     'note_id' : 1,
@@ -137,29 +199,58 @@ class TestRestAPI(unittest.TestCase):
                 }
                 resp = self.app.post('/api/clauses', data=data, content_type='multipart/form-data')
                 data = json.loads(resp.data)
-            except Exception as exc:
-                logger.debug("Cannot POST new clause to db(Clauses), Error : {0}".format(exc))
-                print('POST new clause, Error : {0}'.format(exc))
-            finally:
-                data = json.loads(resp.data)
                 self.assertIsNotNone(data['clause_id'])
                 self.assertEqual(resp.status_code, 200)
 
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+
     # @unittest.skip("skipping")
     def test_delete_clause(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
                 resp = self.app.delete('/api/clauses/2')
                 data = json.loads(resp.data)
-            except Exception as exc:
-                logger.debug("Cannot DELETE clause from db(Clauses), Error : {0}".format(exc))
-                print('DELETE clause, Error : {0}'.format(exc))
-            finally:
                 self.assertEqual(resp.status_code, 200)
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
     # @unittest.skip("skipping")
     def test_put_clause(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
                 data = {
                     'title' : '변경된 제목',
@@ -167,23 +258,38 @@ class TestRestAPI(unittest.TestCase):
                 }
                 resp = self.app.put('/api/clauses/2', data=data, content_type='multipart/form-data')
                 data = json.loads(resp.data)
-            except Exception as exc:
-                logger.debug("Cannot PUT clause to db(Clauses), Error : {0}".format(exc))
-                print('PUT cluase title, contents, Error : {0}'.format(exc))
-            finally:
                 self.assertIsNotNone(data['clause'])
                 self.assertNotEqual(len(data['clause']), 0)
                 self.assertEqual(resp.status_code, 200)
 
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+
 
     # @unittest.skip("skipping")
     def test_get_clausepoints(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
                 # update for testing
-                sqlalchemy.update_data_to_db(sqlalchemy.ClausePoints, {'clause_id': 7}, {'imp': 0, 'und': 1})
-                sqlalchemy.update_data_to_db(sqlalchemy.ClausePoints, {'clause_id': 6}, {'imp': 1, 'und': 1})
-                sqlalchemy.update_data_to_db(sqlalchemy.ClausePoints, {'clause_id': 5}, {'imp': 1, 'und': 1})
+                sqlalchemy_orm.update_data_to_db(sqlalchemy_orm.ClausePoints, {'clause_id': 7}, {'imp': 0, 'und': 1})
+                sqlalchemy_orm.update_data_to_db(sqlalchemy_orm.ClausePoints, {'clause_id': 6}, {'imp': 1, 'und': 1})
+                sqlalchemy_orm.update_data_to_db(sqlalchemy_orm.ClausePoints, {'clause_id': 5}, {'imp': 1, 'und': 1})
 
                 params = {
                     'imp' : 1,
@@ -191,18 +297,33 @@ class TestRestAPI(unittest.TestCase):
                 }
                 resp = self.app.get('/api/notes/2/clausePoints', query_string=params)
                 data = json.loads(resp.data)
-            except Exception as exc:
-                logger.debug("Cannot GET clausepoint to db(ClausePoints), Error : {0}".format(exc))
-                print('GET clausepoint, Error : {0}'.format(exc))
-            finally:
-
                 self.assertEqual(resp.status_code, 200)
                 self.assertIsNotNone(data['clause_points'])
                 self.assertNotEqual(len(data['clause_points']), 0)
 
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+
+
     # @unittest.skip("skipping")
     def test_put_clausepoint(self):
-        with studi.app.app_context():
+        with app.app_context():
             try:
                 data = {
                     'imp' : 1,
@@ -210,13 +331,28 @@ class TestRestAPI(unittest.TestCase):
                 }
                 resp = self.app.put('/api/clausePoints/1', data = data, content_type='multipart/form-data')
                 data = json.loads(resp.data)
-            except Exception as exc:
-                logger.debug("Cannot PUT clausepoint to db(ClausePoints), Error : {0}".format(exc))
-                print('PUT clausepoint, Error : {0}'.format(exc))
-            finally:
                 self.assertEqual(resp.status_code, 200)
                 self.assertIsNotNone(data['clause_point'])
                 self.assertNotEqual(len(data['clause_point']), 0)
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
 if __name__ == "__main__":

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,22 +1,23 @@
 import logging
 import os
+import sqlalchemy
 import unittest
 
 from studi import app
-from studi import sqlalchemy
-from studi import upload
-from studi.sqlalchemy import Notes, ClausePoints, Clauses
+from studi import sqlalchemy_orm, upload, util, custom_error
+from studi.sqlalchemy_orm import Notes, ClausePoints, Clauses
 
 
 def gen_logger(test_name):
     logger = logging.getLogger(test_name)
     logger.setLevel(logging.DEBUG)
-    logger_handler = logging.FileHandler(os.path.join(app.config['LOG_DIR'], test_name + '.log'))
+    logger_handler = logging.FileHandler(os.path.join(app.config['TEST_LOG_DIR'], test_name + '.log'))
     logger_handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     logger_handler.setFormatter(formatter)
     logger.addHandler(logger_handler)
     return logger
+
 
 test_name = "test_select"
 logger = gen_logger(test_name)
@@ -29,13 +30,12 @@ class TestSelectDB(unittest.TestCase):
 
     def setUp(self):
         self.app = app.test_client()
-        app.testing = True
         app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db/test_studi.db'
 
         # create new testing db & insert dummy data
         if os.path.exists("../studi/db/test_studi.db"):
-            sqlalchemy.drop_db(False)
-        self.db = sqlalchemy.create_db(False)
+            sqlalchemy_orm.drop_db(False)
+        self.db = sqlalchemy_orm.create_db(False)
         upload.insert_csv_to_db(False)
 
 
@@ -43,51 +43,115 @@ class TestSelectDB(unittest.TestCase):
         with app.app_context():
             try:
                 result = None
-                result = sqlalchemy.get_all_data_from_db(Notes)
-            except:
-                logger.debug('Cannot select Notes')
-            finally:
+                result = sqlalchemy_orm.get_all_data_from_db(Notes)
                 self.assertIsNotNone(result)
                 self.assertIsInstance(result, list)
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
     def test_select_clauses_by_clause_id(self):
         with app.app_context():
             try:
-                result = sqlalchemy.get_item_from_db(Clauses, {'clause_id' : 1})
-            except Exception as exc:
-                logger.debug("Cannot select Clauses, clause_id : 1, exc : {0} ".format(exc))
-            finally:
+                result = sqlalchemy_orm.get_item_from_db(Clauses, {'clause_id' : 1})
                 self.assertIsNotNone(result)
                 self.assertNotEqual(len(result), 0)
                 self.assertEqual(result[0]['clause_id'], 1)
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
     def test_select_clauses_by_note_id(self):
         with app.app_context():
             try:
-                result = sqlalchemy.get_item_from_db(Clauses, {'note_id':1})
-            except:
-                logger.debug("Cannot select Clauses, note_id : 1, note_id : 1")
-            finally:
+                result = sqlalchemy_orm.get_item_from_db(Clauses, {'note_id':1})
                 self.assertIsNotNone(result)
                 self.assertIsInstance(result, list)
                 self.assertNotEqual(len(result), 0)
                 self.assertEqual(result[0]['note_id'], 1)
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
     def test_select_clausePoints_by_note_id(self):
         with app.app_context():
             try:
-                result = sqlalchemy.get_item_from_db(ClausePoints, {'note_id':1, 'clause_id':1})
-            except:
-                logger.debug("Cannot select ClausePoints, note_id : 1, caluse_id : 1")
-            finally:
+                result = sqlalchemy_orm.get_item_from_db(ClausePoints, {'note_id':1, 'clause_id':1})
                 self.assertIsNotNone(result)
                 self.assertIsInstance(result, list)
                 self.assertNotEqual(len(result), 0)
                 self.assertEqual(result[0]['note_id'], 1)
                 self.assertEqual(result[0]['clause_id'], 1)
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
 if __name__ == '__main__':

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,21 +1,23 @@
 import logging
 import os
+import sqlalchemy
 import unittest
 
 from studi import app
-from studi import sqlalchemy
-from studi import upload
-from studi.sqlalchemy import Notes, Clauses, ClausePoints
+from studi import sqlalchemy_orm, upload, util, custom_error
+from studi.sqlalchemy_orm import Notes, ClausePoints, Clauses
+
 
 def gen_logger(test_name):
     logger = logging.getLogger(test_name)
     logger.setLevel(logging.DEBUG)
-    logger_handler = logging.FileHandler(os.path.join(app.config['LOG_DIR'], test_name + '.log'))
+    logger_handler = logging.FileHandler(os.path.join(app.config['TEST_LOG_DIR'], test_name + '.log'))
     logger_handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     logger_handler.setFormatter(formatter)
     logger.addHandler(logger_handler)
     return logger
+
 
 test_name = "test_update"
 logger = gen_logger(test_name)
@@ -28,13 +30,12 @@ class TestUpdateDB(unittest.TestCase):
 
     def setUp(self):
         self.app = app.test_client()
-        app.testing = True
         app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db/test_studi.db'
 
         #create new tesint DB & insert dummy data
         if os.path.exists("../studi/db/test_studi.db"):
-            sqlalchemy.drop_db(False)
-        sqlalchemy.create_db(False)
+            sqlalchemy_orm.drop_db(False)
+        sqlalchemy_orm.create_db(False)
         upload.insert_csv_to_db(False)  # note_id : 1
         upload.insert_csv_to_db(False)  # note_id : 2
         upload.insert_csv_to_db(False)  # note_id : 3
@@ -43,39 +44,87 @@ class TestUpdateDB(unittest.TestCase):
     def test_update_note_name(self):
         with app.app_context():
             try:
-                sqlalchemy.update_data_to_db(Notes, {'note_id' : 1}, {'note_name' : '새로운 노트 이름'})
-            except Exception as exc:
-                logger.debug("Cannot UPDATE notename, Error: {0}".format(exc))
-            finally:
-                result = sqlalchemy.get_item_from_db(Notes, {'note_id' : 1})
+                sqlalchemy_orm.update_data_to_db(Notes, {'note_id' : 1}, {'note_name' : '새로운 노트 이름'})
+                result = sqlalchemy_orm.get_item_from_db(Notes, {'note_id' : 1})
                 result = result[0]
                 self.assertEqual(result['note_name'], '새로운 노트 이름')
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
     def test_update_clauses(self):
         with app.app_context():
             try:
-                sqlalchemy.update_data_to_db(Clauses, {'note_id' : 1, 'clause_id' : 2}, {'title': '바뀐 제목', 'contents' : "바뀐 내용"})
-            except Exception as exc:
-                logger.debug("Cannot UPDATE clause(title, contents), Error: {0}".format(exc))
-            finally:
-                result = sqlalchemy.get_item_from_db(Clauses, {'note_id' : 1, 'clause_id':2})
+                sqlalchemy_orm.update_data_to_db(Clauses, {'note_id' : 1, 'clause_id' : 2}, {'title': '바뀐 제목', 'contents' : "바뀐 내용"})
+                result = sqlalchemy_orm.get_item_from_db(Clauses, {'note_id' : 1, 'clause_id':2})
                 result = result[0]
                 self.assertEqual(result['title'], '바뀐 제목')
                 self.assertEqual(result['contents'], '바뀐 내용')
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
     def test_update_clausePoints(self):
         with app.app_context():
             try:
-                sqlalchemy.update_data_to_db(ClausePoints, {'clause_id' : 3}, {'imp' : 1, 'und' : 2})
-            except Exception as exc:
-                logger.debug("Cannot UPDATE clausePoints(imp, und), Error: {0}".format(exc))
-            finally:
-                result = sqlalchemy.get_item_from_db(ClausePoints, {'clause_id' : 3})
+                sqlalchemy_orm.update_data_to_db(ClausePoints, {'clause_id' : 3}, {'imp' : 1, 'und' : 2})
+                result = sqlalchemy_orm.get_item_from_db(ClausePoints, {'clause_id' : 3})
                 result = result[0]
                 self.assertEqual(result['imp'], 1)
                 self.assertEqual(result['und'], 2)
+
+            except sqlalchemy.exc.SQLAlchemyError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.SQLAlchemyError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except AssertionError:
+                error_message = util.traceback_custom_error()
+                error = custom_error.AssertionError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
+            except:
+                error_message = util.traceback_custom_error()
+                error = custom_error.UnExpectedError(error_message)
+                error.set_logger(logger)
+                error.to_dict()
+                raise
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 log and exception 처리

- decorator를 활용한 requsest & response에 대한 로그 남기기
- config.py(기존 default_setting.py) 파일에서 TESTING, DEBUG, ENV에 대한 설정 적용
- (기존에는 setting.cfg의 설정 사항들을 최종 적용했으므로 config.py의 설정이 제대로 적용이 안되고 있었음)
- tests/ 이하의 코드에 대한 log 파일의 위치를 별도로 지정

* config 사항에 대한 설정을 객체를 활용하는 방식으로 쉽게 할 수 있도록 변경할 수 있도록 해야 할 것 같음